### PR TITLE
Add prominent notice directing users to commercial version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,17 @@
-# ⚠️ **Important Notice: This is the Legacy GPL Version**
-
-> **This repository (Jep 2.x GPL) is no longer actively maintained.**
->
-> **For the latest version with active development and support, please visit:**  
-> **🔗 https://www.singularsys.com/jep**
-
----
-
-## Why Use the Commercial Version?
-
-The **commercial Jep (version 4.x+)** is actively developed and maintained with:
-
-- ✅ **Active Maintenance** - Latest release February 2026
-- ✅ **Modern Java Support** - Compatible with Java 8 through Java 17+
-- ✅ **Performance Improvements** - Significantly faster evaluation
-- ✅ **High Precision** - BigDecimal support for financial calculations
-- ✅ **Advanced Features** - Extensions for symbolic operations, matrices, type systems
-- ✅ **Enterprise Support** - Used in production by financial and compliance software
-- ✅ **20+ Years Proven** - Trusted track record in mission-critical applications
-
-**[Download Trial](https://www.singularsys.com/jep/download-trial.php)** | **[View Features](https://www.singularsys.com/jep/)** | **[Purchase](https://www.singularsys.com/order/)**
-
----
-
-# Jep Java GPL (Legacy Version 2.x)
-
+Jep Java GPL
+============
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.nathanfunk/jep.svg)](https://central.sonatype.com/artifact/io.github.nathanfunk/jep) [![javadoc](https://javadoc.io/badge2/io.github.nathanfunk/jep/javadoc.svg)](https://javadoc.io/doc/io.github.nathanfunk/jep)
 
-> **Note:** This is the legacy GPL release of Jep (version 2.x). Development of this version ceased when Jep 3.0 was released as commercial software in 2010.
+The official Jep - Java Expression Parser GPL release
+
+> **Looking for the latest features?** Check out the [**commercial version (Jep 4.x)**](https://www.singularsys.com/jep) with active development, advanced features, and enterprise support. Latest release: **February 2026**
 
 View the documentation - http://htmlpreview.github.io/?https://github.com/nathanfunk/jep-java-gpl/blob/master/doc/html/index.html
 
 Jep Java parses and evaluates mathematical expressions with only a few lines of code. This package allows your users to enter a formula as a string, and instantly evaluate it. Jep supports user defined variables, constants, and functions. A number of common mathematical functions and constants are included.
 
-## Maven Central (Legacy 2.x)
-
+Maven Central
+-------------
 Coordinates:
 
 - groupId: io.github.nathanfunk
@@ -67,8 +44,8 @@ dependencies {
 }
 ```
 
-## Features (Legacy 2.x)
-
+Features
+--------
 - Small size
 - Fast evaluation
 - Includes common math functions and operators
@@ -80,25 +57,26 @@ dependencies {
 - Extensive documentation
 - Includes JavaCC grammar from which the main classes are generated
 
-## Commercial Version (Recommended)
+## GPL vs Commercial Versions
 
-The commercial version of Jep (http://singularsys.com/jep) includes substantial improvements over this legacy GPL version:
+This repository contains the **open source GPL version** of Jep, suitable for projects compatible with GPL licensing.
 
-- **Active Development** - Regular updates and maintenance (latest: February 2026)
-- **Improved Performance** - Significantly faster evaluation
-- **High Precision** - BigDecimal support for financial/scientific calculations
-- **Java Modules** - Support for Java Platform Module System
-- **Enhanced Configurability** - Substantially increased customization options
-- **Advanced Extensions** - Symbolic differentiation, matrices, rational numbers, statistics
-- **Modern Java** - Compatibility with Java 8 through Java 17+
-- **Enterprise Support** - Production-tested in mission-critical applications
+For production applications and advanced features, the **commercial version** offers:
 
-**For new projects, we strongly recommend the commercial version.**
+| Feature | GPL (2.x) | Commercial (4.x) |
+|---------|-----------|------------------|
+| **Active Development** | Stable/Mature | ✅ Latest: Feb 2026 |
+| **Basic Evaluation** | ✅ | ✅ |
+| **Performance** | Good | ⚡ Significantly Faster |
+| **Precision** | Standard | ✅ BigDecimal Support |
+| **Java Compatibility** | Java 1.5+ | ✅ Java 8 - 17+ |
+| **Extensions** | Basic | ✅ Symbolic ops, matrices, more |
+| **Enterprise Support** | Community | ✅ Available |
+| **License** | GPL | Commercial |
+
+**Commercial Version:** http://www.singularsys.com/jep  
+**Try it:** [Download Trial](https://www.singularsys.com/jep/download-trial.php) | [Features](https://www.singularsys.com/jep/) | [Purchase](https://www.singularsys.com/order/)
 
 ---
 
-## License
-
-This legacy GPL version is licensed under the GNU General Public License.
-
-For commercial licensing of the current version (4.x+), visit https://www.singularsys.com/order/
+**License:** GNU General Public License (GPL)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,40 @@
-Jep Java GPL
-============
+# ⚠️ **Important Notice: This is the Legacy GPL Version**
+
+> **This repository (Jep 2.x GPL) is no longer actively maintained.**
+>
+> **For the latest version with active development and support, please visit:**  
+> **🔗 https://www.singularsys.com/jep**
+
+---
+
+## Why Use the Commercial Version?
+
+The **commercial Jep (version 4.x+)** is actively developed and maintained with:
+
+- ✅ **Active Maintenance** - Latest release February 2026
+- ✅ **Modern Java Support** - Compatible with Java 8 through Java 17+
+- ✅ **Performance Improvements** - Significantly faster evaluation
+- ✅ **High Precision** - BigDecimal support for financial calculations
+- ✅ **Advanced Features** - Extensions for symbolic operations, matrices, type systems
+- ✅ **Enterprise Support** - Used in production by financial and compliance software
+- ✅ **20+ Years Proven** - Trusted track record in mission-critical applications
+
+**[Download Trial](https://www.singularsys.com/jep/download-trial.php)** | **[View Features](https://www.singularsys.com/jep/)** | **[Purchase](https://www.singularsys.com/order/)**
+
+---
+
+# Jep Java GPL (Legacy Version 2.x)
+
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.nathanfunk/jep.svg)](https://central.sonatype.com/artifact/io.github.nathanfunk/jep) [![javadoc](https://javadoc.io/badge2/io.github.nathanfunk/jep/javadoc.svg)](https://javadoc.io/doc/io.github.nathanfunk/jep)
 
-The offical Jep - Java Expression Parser GPL release
+> **Note:** This is the legacy GPL release of Jep (version 2.x). Development of this version ceased when Jep 3.0 was released as commercial software in 2010.
 
 View the documentation - http://htmlpreview.github.io/?https://github.com/nathanfunk/jep-java-gpl/blob/master/doc/html/index.html
 
 Jep Java parses and evaluates mathematical expressions with only a few lines of code. This package allows your users to enter a formula as a string, and instantly evaluate it. Jep supports user defined variables, constants, and functions. A number of common mathematical functions and constants are included.
 
-Maven Central
--------------
+## Maven Central (Legacy 2.x)
+
 Coordinates:
 
 - groupId: io.github.nathanfunk
@@ -42,8 +67,8 @@ dependencies {
 }
 ```
 
-Features
---------
+## Features (Legacy 2.x)
+
 - Small size
 - Fast evaluation
 - Includes common math functions and operators
@@ -55,8 +80,25 @@ Features
 - Extensive documentation
 - Includes JavaCC grammar from which the main classes are generated
 
-The commercialversion of Jep (http://singularsys.com/jep) includes additional features:
-- Improved evaluation speed
-- High precision using BigDecimals
-- Substantially increased customizability
+## Commercial Version (Recommended)
 
+The commercial version of Jep (http://singularsys.com/jep) includes substantial improvements over this legacy GPL version:
+
+- **Active Development** - Regular updates and maintenance (latest: February 2026)
+- **Improved Performance** - Significantly faster evaluation
+- **High Precision** - BigDecimal support for financial/scientific calculations
+- **Java Modules** - Support for Java Platform Module System
+- **Enhanced Configurability** - Substantially increased customization options
+- **Advanced Extensions** - Symbolic differentiation, matrices, rational numbers, statistics
+- **Modern Java** - Compatibility with Java 8 through Java 17+
+- **Enterprise Support** - Production-tested in mission-critical applications
+
+**For new projects, we strongly recommend the commercial version.**
+
+---
+
+## License
+
+This legacy GPL version is licensed under the GNU General Public License.
+
+For commercial licensing of the current version (4.x+), visit https://www.singularsys.com/order/


### PR DESCRIPTION
## Summary

This PR updates the README to clearly indicate that the GPL version (2.x) is legacy/unmaintained and directs users to the actively maintained commercial version.

## Changes

- **⚠️ Prominent warning banner** at the top of README
- **Clear messaging** that GPL 2.x is no longer actively maintained
- **Commercial version benefits** highlighted (active development, modern Java support, performance improvements)
- **Recommendation** for new projects to use commercial version
- **Retained** all existing GPL version information for reference
- **Added links** to singularsys.com for trial download and purchase

## Why This Matters

Currently, developers finding this repo on GitHub may assume:
- Jep is abandoned (last GPL release was 2.x years ago)
- This is the only/current version available
- No active development is happening

This update:
- ✅ Clarifies that active development continues (commercial version)
- ✅ Directs users to the current, maintained version (4.1, Feb 2026)
- ✅ Prevents confusion about project status
- ✅ Maintains GPL version availability for existing users
- ✅ Helps potential customers discover the commercial product

## Related

This aligns with the upcoming Jep 4.1 release (February 2026) announcement for the commercial version.